### PR TITLE
Added internal _with_stencilbuffer BooleanProperty to Graph class.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -145,12 +145,18 @@ class Graph(Widget):
     label_options = DictProperty()
     '''Label options that will be passed to `:class:`kivy.uix.Label`.
     '''
+    
+    use_framebuffer = BooleanProperty(True)
+    '''Whether Graph's FBO should use FrameBuffer (True) or not (False).
+    
+    :data:`use_framebuffer` is a :class:`~kivy.properties.BooleanProperty`, defaults
+    to True.'''
 
     def __init__(self, **kwargs):
         super(Graph, self).__init__(**kwargs)
 
         with self.canvas:
-            self._fbo = Fbo(size=self.size, with_stencilbuffer=True)
+            self._fbo = Fbo(size=self.size, with_stencilbuffer=self.use_framebuffer)
 
         with self._fbo:
             self._background_color = Color(*self.background_color)

--- a/__init__.py
+++ b/__init__.py
@@ -146,17 +146,22 @@ class Graph(Widget):
     '''Label options that will be passed to `:class:`kivy.uix.Label`.
     '''
     
-    use_framebuffer = BooleanProperty(True)
-    '''Whether Graph's FBO should use FrameBuffer (True) or not (False).
+    _with_stencilbuffer = BooleanProperty(True)
+    '''Whether :class:`Graph`'s FBO should use FrameBuffer (True) or not (False).
     
-    :data:`use_framebuffer` is a :class:`~kivy.properties.BooleanProperty`, defaults
+    .. warning:: This property is internal and so should be used with care. It can break
+    some other graphic instructions used by the :class:`Graph`, for example you can have
+    problems when drawing :class:`SmoothLinePlot` plots, so use it only when you know
+    what exactly you are doing.
+    
+    :data:`_with_stencilbuffer` is a :class:`~kivy.properties.BooleanProperty`, defaults
     to True.'''
 
     def __init__(self, **kwargs):
         super(Graph, self).__init__(**kwargs)
 
         with self.canvas:
-            self._fbo = Fbo(size=self.size, with_stencilbuffer=self.use_framebuffer)
+            self._fbo = Fbo(size=self.size, with_stencilbuffer=self._with_stencilbuffer)
 
         with self._fbo:
             self._background_color = Color(*self.background_color)


### PR DESCRIPTION
Turning the FBO framebuffer usage off can solve the Graph/Plots problems when used with ScrollView, ScreenManager or Carousel. I have added the _with_stencilbuffer BooleanProperty to the Graph so the user can easily chage the framebuffer usage both from py or kv. Such property exposition will make Graph a little better about Kivy standards about exposing important properties to the end user.

Defaults to True, so it wont change the default behavior of the Graph.